### PR TITLE
Fix GitHub Actions workflow issue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,14 +4,14 @@ on:
   push:
     branches: [ main ]
     paths-ignore:
-      - '*.md'
+      - '**/*.md'
       - 'LICENSE'
       - 'docs/**'
       - '.gitignore'
   pull_request:
     branches: [ main, develop ]
     paths-ignore:
-      - '*.md'
+      - '**/*.md'
       - 'LICENSE'
       - 'docs/**'
       - '.gitignore'


### PR DESCRIPTION
Add paths-ignore to GitHub Actions workflow to avoid running tests when only documentation files are modified (README, CLAUDE.md, LICENSE, docs/).

Closes #18 