### PR TITLE
Fix unsubscribe call in UI

### DIFF
--- a/webserver/src/lib/stores/auth.ts
+++ b/webserver/src/lib/stores/auth.ts
@@ -3,7 +3,7 @@
  * Stores credentials in memory and persists to localStorage.
  */
 
-import { writable } from 'svelte/store';
+import { writable, get } from 'svelte/store';
 import { browser } from '$app/environment';
 import type { Scribe } from '$lib/api';
 
@@ -35,7 +35,8 @@ function createAuthStore() {
 		}
 	}
 
-	const { subscribe, set, update } = writable<AuthState>(initialState);
+	const store = writable<AuthState>(initialState);
+	const { subscribe, set, update } = store;
 
 	return {
 		subscribe,
@@ -96,13 +97,11 @@ function createAuthStore() {
 		 * Get current auth credentials
 		 */
 		getCredentials: (): { username: string; password: string } | null => {
-			let credentials: { username: string; password: string } | null = null;
-			subscribe((state) => {
-				if (state.isAuthenticated) {
-					credentials = { username: state.username, password: state.password };
-				}
-			})();
-			return credentials;
+			const state = get(store);
+			if (state.isAuthenticated) {
+				return { username: state.username, password: state.password };
+			}
+			return null;
 		}
 	};
 }


### PR DESCRIPTION
Replace confusing subscribe-then-unsubscribe pattern with the proper Svelte idiom using get() from svelte/store. The previous pattern immediately invoked the unsubscribe function, which was unclear and not idiomatic even though it worked due to synchronous callback.

Fixes #14