### PR TITLE
Fix warnings in integration test suites

### DIFF
--- a/apiserver/api/posts.py
+++ b/apiserver/api/posts.py
@@ -141,7 +141,7 @@ def get_entry(current_scribe, entry_id):
              -u alice:secret123 \\
              -H "Accept: application/vnd.api+json"
     """
-    entry = Entry.query.get(entry_id)
+    entry = db.session.get(Entry, entry_id)
 
     # Return 404 if entry doesn't exist
     if not entry:
@@ -210,7 +210,7 @@ def update_entry(current_scribe, entry_id):
              -H "Content-Type: application/json" \\
              -d '{"content": "Updated content", "visibility": "private"}'
     """
-    entry = Entry.query.get(entry_id)
+    entry = db.session.get(Entry, entry_id)
 
     # Return 404 if entry doesn't exist
     if not entry:
@@ -316,7 +316,7 @@ def delete_entry(current_scribe, entry_id):
              -u alice:secret123 \\
              -i  # -i flag shows 204 status code
     """
-    entry = Entry.query.get(entry_id)
+    entry = db.session.get(Entry, entry_id)
 
     # Return 404 if entry doesn't exist
     if not entry:

--- a/apiserver/api/users.py
+++ b/apiserver/api/users.py
@@ -32,7 +32,7 @@ def get_scribe(scribe_id):
         curl -X GET http://localhost:5000/api/scribes/1 \\
              -H "Accept: application/vnd.api+json"
     """
-    scribe = Scribe.query.get(scribe_id)
+    scribe = db.session.get(Scribe, scribe_id)
 
     if not scribe:
         return (
@@ -84,7 +84,7 @@ def update_scribe(current_scribe, scribe_id):
              -d '{"email": "newemail@example.com", "bio": "Updated bio"}'
     """
     # Check if scribe exists
-    scribe = Scribe.query.get(scribe_id)
+    scribe = db.session.get(Scribe, scribe_id)
 
     if not scribe:
         return (
@@ -217,7 +217,7 @@ def delete_scribe(current_scribe, scribe_id):
              -i  # -i flag shows 204 status code
     """
     # Check if scribe exists
-    scribe = Scribe.query.get(scribe_id)
+    scribe = db.session.get(Scribe, scribe_id)
 
     if not scribe:
         return (

--- a/tests/unit/test_entry_endpoints.py
+++ b/tests/unit/test_entry_endpoints.py
@@ -317,7 +317,7 @@ class TestUpdateEntryEndpoint:
 
         # Verify database was updated
         db.session.expire_all()
-        updated_entry = Entry.query.get(sample_entry.id)
+        updated_entry = db.session.get(Entry, sample_entry.id)
         assert updated_entry.content == new_content
 
     def test_update_entry_visibility_success(self, client, sample_entry, auth_headers, db):
@@ -464,7 +464,7 @@ class TestDeleteEntryEndpoint:
         assert response.data == b""
 
         # Verify entry was deleted from database
-        deleted_entry = Entry.query.get(entry_id)
+        deleted_entry = db.session.get(Entry, entry_id)
         assert deleted_entry is None
 
     def test_delete_entry_no_auth(self, client, sample_entry):
@@ -534,7 +534,7 @@ class TestDeleteEntryEndpoint:
         )
 
         assert response.status_code == 204
-        assert Entry.query.get(entry_id) is None
+        assert db.session.get(Entry, entry_id) is None
 
 
 @pytest.mark.unit

--- a/tests/unit/test_scribe_endpoints.py
+++ b/tests/unit/test_scribe_endpoints.py
@@ -108,7 +108,7 @@ class TestUpdateScribeEndpoint:
 
         # Verify database was updated
         db.session.expire_all()
-        updated_scribe = Scribe.query.get(sample_scribe.id)
+        updated_scribe = db.session.get(Scribe, sample_scribe.id)
         assert updated_scribe.email == new_email
 
     def test_update_scribe_bio_success(self, client, sample_scribe, auth_headers):
@@ -137,7 +137,7 @@ class TestUpdateScribeEndpoint:
 
         # Verify password was updated by trying to authenticate with new password
         db.session.expire_all()
-        updated_scribe = Scribe.query.get(sample_scribe.id)
+        updated_scribe = db.session.get(Scribe, sample_scribe.id)
         assert updated_scribe.check_password(new_password)
         assert not updated_scribe.check_password("testpass123")
 
@@ -293,7 +293,7 @@ class TestDeleteScribeEndpoint:
         assert response.data == b""
 
         # Verify scribe was deleted from database
-        deleted_scribe = Scribe.query.get(scribe_id)
+        deleted_scribe = db.session.get(Scribe, scribe_id)
         assert deleted_scribe is None
 
     def test_delete_scribe_cascade_deletes_entries(self, client, sample_scribe, sample_entry, auth_headers, db):
@@ -302,7 +302,7 @@ class TestDeleteScribeEndpoint:
         entry_id = sample_entry.id
 
         # Verify entry exists before deletion
-        entry = Entry.query.get(entry_id)
+        entry = db.session.get(Entry, entry_id)
         assert entry is not None
         assert entry.scribe_id == scribe_id
 
@@ -314,7 +314,7 @@ class TestDeleteScribeEndpoint:
         assert response.status_code == 204
 
         # Verify entry was cascade deleted
-        deleted_entry = Entry.query.get(entry_id)
+        deleted_entry = db.session.get(Entry, entry_id)
         assert deleted_entry is None
 
     def test_delete_scribe_with_multiple_entries(self, client, sample_scribe, auth_headers, entry_factory, db):
@@ -336,7 +336,7 @@ class TestDeleteScribeEndpoint:
 
         # Verify all entries were cascade deleted
         for entry_id in entry_ids:
-            deleted_entry = Entry.query.get(entry_id)
+            deleted_entry = db.session.get(Entry, entry_id)
             assert deleted_entry is None
 
     def test_delete_scribe_no_auth(self, client, sample_scribe):


### PR DESCRIPTION
Replace deprecated Model.query.get(id) pattern with the modern db.session.get(Model, id) approach across all API endpoints.

The Query.get() method has been deprecated since SQLAlchemy 1.x and becomes a legacy construct in 2.0. This change eliminates 94 deprecation warnings that were appearing during integration test runs.

Fixes: #9