### PR TITLE
Configure daily test schedule for main branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,12 @@
 name: Tests
 
 on:
-  push:
-    branches: [ main ]
-    paths-ignore:
-      - '**/*.md'
-      - 'LICENSE'
-      - 'docs/**'
+  # Daily test run on main branch at 11:00 PM UTC (end of day)
+  # This clubs together all commits from the day and tests them as a batch
+  schedule:
+    - cron: '0 23 * * *'  # Runs at 23:00 UTC every day
+
+  # Run tests on all pull requests
   pull_request:
     types: [ opened, synchronize, reopened, ready_for_review ]
     branches: [ main, develop ]
@@ -14,6 +14,9 @@ on:
       - '**/*.md'
       - 'LICENSE'
       - 'docs/**'
+
+  # Allow manual trigger for on-demand testing
+  workflow_dispatch:
 
 jobs:
   apiserver-tests:


### PR DESCRIPTION
- Remove push trigger for main branch to avoid testing on every commit
- Add scheduled daily test run at 11:00 PM UTC (end of day)
- Keep PR testing unchanged to maintain quality gates
- Add workflow_dispatch for manual test triggers when needed

This clubs commits throughout the day and tests them as a single batch, reducing CI/CD costs while maintaining test coverage.